### PR TITLE
商品参考画像追加

### DIFF
--- a/app/assets/stylesheets/products.scss
+++ b/app/assets/stylesheets/products.scss
@@ -208,7 +208,8 @@
       background-color: #ffffff;
       margin:10px;
       &__img{
-        background-color: hotpink;
+        background-image: image-url("/images2.jpg");
+        background-size: cover;
         width: 153px;
         height: 160px;
       }

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -38,7 +38,6 @@
   -# .google-link
   -# = link_to "#" do
   -#   = image_tag "/link/en_badge_web_generic.png", class:"google_image", alt:""
-
 .main
   .main__top
     .main__top__header


### PR DESCRIPTION
#What
topページの完成にあたり、商品一覧ページにサンプル画像を表示させるために配置（仮置き）。
#Why
top商品一覧ページに画像が反映されるか確認できるようにするため。